### PR TITLE
Description format fixes

### DIFF
--- a/g3cip/languages/english/game.tra
+++ b/g3cip/languages/english/game.tra
@@ -1,17 +1,17 @@
 @1000 = ~Akkabar's Battleblade~
-@1001 = ~The rulers of the Shoon Imperium possessed unique magical rings known as Qysari Rings. The term "qysar," meaning "emperor," was adopted by Amahl Shoon III, the first in a line of imperial rulers. These rings were a subset of shoonrings, magical rings crafted in the Shoon Imperium during Calimshan's sixth age (27 – 450 DR). Shoonrings were distinguished by their specific construction and enchantment methods. According to the slave scribe Rativ ym Shoon, who documented the rings in 356 DR, there were twelve known Qysari Rings. This information was later included in "The Magics of the South" by Zatan Arrowswift, the Herald of Athkatla. However, only ten rings are currently described, with two of those having uncertain origins. 
+@1001 = ~The rulers of the Shoon Imperium possessed unique magical rings known as Qysari Rings. The term "qysar," meaning "emperor," was adopted by Amahl Shoon III, the first in a line of imperial rulers. These rings were a subset of shoonrings, magical rings crafted in the Shoon Imperium during Calimshan's sixth age (27 – 450 DR). Shoonrings were distinguished by their specific construction and enchantment methods. According to the slave scribe Rativ ym Shoon, who documented the rings in 356 DR, there were twelve known Qysari Rings. This information was later included in "The Magics of the South" by Zatan Arrowswift, the Herald of Athkatla. However, only ten rings are currently described, with two of those having uncertain origins.
 
 Akkabar's legendary ring, known as the battleblade ring, held the distinction of being the inaugural Qysari Ring. This remarkable artifact possessed the ability to conjure a barrier of blades when activated by a specific verbal command.
 
 STATISTICS:
 
+Equipped abilities:
+– Armor Class: +2
+
 Charge abilities:
 – Blade Barrier once per day
   Special: Creates a wall of circling, razor-sharp blades
   Duration: 1 turn
-
-Equipped abilities:
-– Armor Class: +2
 
 Weight: 0~
 @1002 = ~A Caster's Guide to Self-Defense~
@@ -23,6 +23,7 @@ Charge abilities:
 – Haste once per day
   Special: All creatures affected function at double their normal movement rate
   Duration: 13 rounds
+
 – Mirror Image once per day
   Special: Caster causes from 2 to 8 exact duplicates of <PRO_HIMHER>self to come into being
   Duration: 13 rounds
@@ -38,10 +39,11 @@ Charge abilities:
 – Summon Fire Elemental once per day
   Special: A fire elemental is summoned in the vicinity of the caster
   Duration: 10 turns
+
 – Summon Air Elemental Image once per day
   Special: An air elemental is summoned in the vicinity of the caster
   Duration: 10 turns
-  
+
 Weight: 0~
 @1006 = ~The Power of Real Change~
 @1007 = ~The majority of this book is self-help advice, but in the very last chapter contains arcane methodologies for the truly desperate.
@@ -123,19 +125,19 @@ Type: One-handed
 Requires:
  3 Strength
 
-Weight: 0~ 
+Weight: 0~
 @1016 = ~Never Alone~
 @1017 = ~This cowl is made of fur and has the color of a gibberling. There is strength in numbers and whenever you are in trouble, you can call for help.
 
 STATISTICS:
 
+Equipped abilities:
+– Immunity to fear and panic
+
 Charge abilities:
 – Mirror Image three times per day
   Special: Caster causes from 2 to 8 exact duplicates of <PRO_HIMHER>self to come into being
   Duration: 6 rounds
-
-Equipped abilities:
-– Immunity to fear and panic
 
 Weight: 1~
 @1018 = ~Tinkerer's Spectacles~
@@ -143,16 +145,17 @@ Weight: 1~
 
 STATISTICS:
 
-Charge abilities:
-– Knock once per day
-  Special: Opens locked, held, or wizard-locked doors
-  Duration: Instant
-
 Equipped abilities:
 – Open Locks: +5%
 – Find Traps: +25%
 – +2 THAC0 against Spiders (Thieves only)
 – Wearer gets confused for 2 rounds on equipping the item if not a thief or gnome
+
+Charge abilities:
+– Knock once per day
+  Special: Opens locked, held, or wizard-locked doors
+  Duration: Instant
+
 
 Weight: 1~
 @1020 = ~Uses Akkabar's Battleblade~
@@ -178,10 +181,10 @@ Janta's fortunes turned when he began wearing these goggles, and he was overhear
 STATISTICS:
 
 Equipped abilities:
-- Hide in Shadows: +10%
-- Detect Traps: +10%
-- Open Locks: +10%
-- Blinds wearer when they see an enemy 
+– Hide in Shadows: +10%
+– Detect Traps: +10%
+– Open Locks: +10%
+– Blinds wearer when they see an enemy
 
 Weight: 0~
 @1025 = ~Executioner Putty~
@@ -199,7 +202,7 @@ Weight: 0~
 @1027 = ~Executioner's Eyes~
 @1028 = ~Enhances the vision of allies, allowing them to see the hidden weaknesses of all creatures. The divination grants a +4 attack bonus and a +4 bonus to critical hits (if you critical hit on a natural roll of 20, you now critically hit on any roll from 16-20) to all allies within a 15-foot radius for 10 rounds.~
 @1029 = ~The Realmshaper's Brush~
-@1030 = ~Trying to profit from the strength of greater beings, many years ago the mage Ullion founded a dragon-worshipping cult under the moniker "Son of Drago." Attracting followers with promises of conquest, he sought to secure his authority by enchanting this symbolic weapon for his bodyguard, Jaramor Bold. When the Dragon's Breath strikes an opponent, it releases the harsh flames of a red dragon, the poisonous vapor of the green dragon, the blue dragon's lightning bolt, a spray of a black dragon's acid, and the white dragon's penetrating cold. Unfortunately, Ullion was the first to feel its effects, slain by the ambitious Jaramor, who sought to rule. There was no real power to be had without the mage, so the entire organization soon collapsed on itself. 
+@1030 = ~Trying to profit from the strength of greater beings, many years ago the mage Ullion founded a dragon-worshipping cult under the moniker "Son of Drago." Attracting followers with promises of conquest, he sought to secure his authority by enchanting this symbolic weapon for his bodyguard, Jaramor Bold. When the Dragon's Breath strikes an opponent, it releases the harsh flames of a red dragon, the poisonous vapor of the green dragon, the blue dragon's lightning bolt, a spray of a black dragon's acid, and the white dragon's penetrating cold. Unfortunately, Ullion was the first to feel its effects, slain by the ambitious Jaramor, who sought to rule. There was no real power to be had without the mage, so the entire organization soon collapsed on itself.
 
 STATISTICS:
 
@@ -328,12 +331,6 @@ Its thirst for life is particularly potent against the pure-hearted, drawing gre
 
 STATISTICS:
 
-Charge abilities:
-– Vampiric Touch once per day
-  Special: Target loses 6d6 Hit Points that are added to the caster's current Hit Points
-  Area of Effect: 1 creature
-  Duration: 1 hour
-
 Equipped abilities:
 – Upon equipping, the dart drinks some of the wielder's blood, temporarily reducing Constitution by 1 point up to once per 24 hours
 
@@ -341,6 +338,12 @@ Combat abilities:
 – Returns to the wielder's hand when thrown
 – 20% chance to steal 1d4 Hit Points from the target
 – 5% chance to restore one forgotten spell slot to the wielder (up to fourth level)
+
+Charge abilities:
+– Vampiric Touch once per day
+  Special: Target loses 6d6 Hit Points that are added to the caster's current Hit Points
+  Area of Effect: 1 creature
+  Duration: 1 hour
 
 THAC0: +4
 Damage: 1d3+4, +1 vs. good creatures
@@ -376,7 +379,7 @@ Combat abilities:
 – 3 points of acid damage to any who damage the wielder
 
 THAC0: +5
-Damage: 1d3+5, +1d3 acid 
+Damage: 1d3+5, +1d3 acid
 Damage type: Missile
 Speed Factor: 0
 Proficiency Type: Dart
@@ -410,7 +413,7 @@ Equipped abilities:
 – Save vs. Breath: +1
 – Resistance to Magic Damage: +20%
 – Hide In Shadows: +10%
-– 20% of Caustic Sheath when attacked
+– 20% chance of being enveloped in Caustic Sheath when hit
   Special: +50% Acid Resistance, 1d6+6 acid damage if hit, attacks deal an additional +3 Acid Damage.
   Duration: 4 rounds
 
@@ -419,12 +422,12 @@ Weight: 2~
 @1065 = ~Cloak of Sound Rest~
 @1066 = ~This cloak is light and travels well, but has a soft, downy appearance. It was created for a Duke Jeffa of Sembia, who enacted cruel policies and feared assassination. Once it is attuned to the wearer, which takes one hour, its protective nature will activate. From that moment, if the wearer is struck by a weapon, the cloak will intercept and absorb the strike. At the same time, it will issue a small explosion of glowing motes, similar to a Glitterdust spell, to disorient the attacker, illuminate invisible assailants, and importantly, wake the wearer. Only one attack will be blocked; the magic will reactivate one hour later.
 
-Sadly for Duke Jeffa, the cloak could not protect him from poison administered by his own cook. 
+Sadly for Duke Jeffa, the cloak could not protect him from poison administered by his own cook.
 
 STATISTICS:
 
 Equipped abilities:
-– Block one weapon attack, once per hour. Upon blocking an attack, cast Glitterdust near the wearer. 
+– Block one weapon attack, once per hour. Upon blocking an attack, cast Glitterdust near the wearer.
 
 Weight: 3~
 @1067 = ~Painted Red~

--- a/g3cip/languages/english/game.tra
+++ b/g3cip/languages/english/game.tra
@@ -372,9 +372,11 @@ This dart is a relic of epic power, its mere presence commanding respect and fea
 
 STATISTICS:
 
+Equipped abilities:
+– Acid Resistance: +20%
+
 Combat abilities:
 – Returns to the wielder's hand when thrown
-– Acid Resistance: +20%
 – 5% chance per hit of a vorpal hit (instant death by decapitation)
 – 3 points of acid damage to any who damage the wielder
 


### PR DESCRIPTION
A spotted a bunch of inconsistencies, thus this pull request:

- The order of equipped, combat, and charge abilities is pretty consistent in that they follow the order: equipped, then combat, then charge abilities. I corrected a few that didn't follow that. See Carsomyr and the Staff of Magi for a complete example.
- The black dragon belt had an issue in the description, where it says something like"20% of Caustic Sheath when attacked". I extended it to be more grammatically sound with "20% chance of being enveloped in Caustic Sheath when hit [hit is more accurate]". Change that to something else if it's not acceptable.
- There was also an odd item using "-" instead of the long hyphen, like the rest. I changed that too, since I think that was an oversight (correct me if I'm wrong).
- Charge abilities seem to be always separated by an two line breaks, not one, so I corrected those that didn't conform to that.
- One of the darts had an equipped ability inside a combat ability: 20% acid resistance

Cheers.